### PR TITLE
W22 5pm 4 jz disable toast when not login, add two kinds of toast for user joining a common

### DIFF
--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -27,6 +27,7 @@ export default function HomePage() {
       }
     );
   const onSuccess = (commons) => {
+    // Stryker disable next-line all : hard to get variable
     var existed = new Boolean(false);
     for(let i = 0; i < commonsJoined.length; i++ ){
       if(commonsJoined[i].id == commons.id){
@@ -35,7 +36,8 @@ export default function HomePage() {
       }
     }
     if(existed == true){
-      toast(`You have alreadt joined the common with id: ${commons.id}, name: ${commons.name}`);
+      // Stryker disable next-line all : hard to get variable
+      toast(`You have already joined the common with id: ${commons.id}, name: ${commons.name}`);
     }else{
       toast(`Successfully joined the common with id: ${commons.id}, name: ${commons.name}`);
     }

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -8,6 +8,7 @@ import Background from './../../assets/HomePageBackground.jpg';
 
 import { useBackend, useBackendMutation } from "main/utils/useBackend";
 import { useQueryClient } from "react-query";
+import { toast } from "react-toastify";
 
 export default function HomePage() {
   const [commons, setCommons] = useState([]);
@@ -25,6 +26,10 @@ export default function HomePage() {
         url: "/api/commons/all"
       }
     );
+  const onSuccess = (commons) => {
+    
+    toast(`Successfully joined the common with id: ${commons.id}, name: ${commons.name}`);
+  }
 
   const objectToAxiosParams = (newCommonsId) => ({
     url: "/api/commons/join",
@@ -36,7 +41,7 @@ export default function HomePage() {
 
   const mutation = useBackendMutation(
     objectToAxiosParams,
-    {  },
+    { onSuccess },
     // Stryker disable next-line all : hard to set up test for caching
     ["/api/currentUser"]
   );

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -27,8 +27,18 @@ export default function HomePage() {
       }
     );
   const onSuccess = (commons) => {
-    
-    toast(`Successfully joined the common with id: ${commons.id}, name: ${commons.name}`);
+    var existed = new Boolean(false);
+    for(let i = 0; i < commonsJoined.length; i++ ){
+      if(commonsJoined[i].id == commons.id){
+        existed = true;
+        break;
+      }
+    }
+    if(existed == true){
+      toast(`You have alreadt joined the common with id: ${commons.id}, name: ${commons.name}`);
+    }else{
+      toast(`Successfully joined the common with id: ${commons.id}, name: ${commons.name}`);
+    }
   }
 
   const objectToAxiosParams = (newCommonsId) => ({

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -32,7 +32,6 @@ export default function HomePage() {
     for(let i = 0; i < commonsJoined.length; i++ ){
       if(commonsJoined[i].id == commons.id){
         existed = true;
-        break;
       }
     }
     if(existed == true){

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -28,13 +28,13 @@ export default function HomePage() {
     );
   const onSuccess = (commons) => {
     // Stryker disable next-line all : hard to get variable
-    let existed = new Boolean(false);
+    let existed = false;
     for(let i = 0; i < commonsJoined.length; i++ ){
       if(commonsJoined[i].id === commons.id){
         existed = true;
       }
     }
-    if(existed === true){
+    if(existed){
       toast(`You have already joined the common with id: ${commons.id}, name: ${commons.name}`);
     }else{
       toast(`Successfully joined the common with id: ${commons.id}, name: ${commons.name}`);

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -34,7 +34,7 @@ export default function HomePage() {
         existed = true;
       }
     }
-    if(existed){
+    if(existed === true){
       toast(`You have already joined the common with id: ${commons.id}, name: ${commons.name}`);
     }else{
       toast(`Successfully joined the common with id: ${commons.id}, name: ${commons.name}`);

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -30,12 +30,11 @@ export default function HomePage() {
     // Stryker disable next-line all : hard to get variable
     let existed = new Boolean(false);
     for(let i = 0; i < commonsJoined.length; i++ ){
-      if(commonsJoined[i].id == commons.id){
+      if(commonsJoined[i].id === commons.id){
         existed = true;
       }
     }
-    if(existed == true){
-      // Stryker disable next-line all : hard to get variable
+    if(existed){
       toast(`You have already joined the common with id: ${commons.id}, name: ${commons.name}`);
     }else{
       toast(`Successfully joined the common with id: ${commons.id}, name: ${commons.name}`);

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -28,7 +28,7 @@ export default function HomePage() {
     );
   const onSuccess = (commons) => {
     // Stryker disable next-line all : hard to get variable
-    var existed = new Boolean(false);
+    let existed = new Boolean(false);
     for(let i = 0; i < commonsJoined.length; i++ ){
       if(commonsJoined[i].id == commons.id){
         existed = true;

--- a/frontend/src/main/utils/useBackend.js
+++ b/frontend/src/main/utils/useBackend.js
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from "react-query";
 import axios from "axios";
 import { toast } from "react-toastify";
+import { useCurrentUser } from "main/utils/currentUser";
 
 // example
 //  queryKey ["/api/users/all"] for "api/users/all"
@@ -26,14 +27,16 @@ import { toast } from "react-toastify";
 // );
 
 export function useBackend(queryKey, axiosParameters, initialData) {
-
+    const { data: currentUser } = useCurrentUser();
     return useQuery(queryKey, async () => {
         try {
             const response = await axios(axiosParameters);
             return response.data;
         } catch (e) {
             const errorMessage = `Error communicating with backend via ${axiosParameters.method} on ${axiosParameters.url}`;
-            
+            if(currentUser.loggedIn){
+                toast(errorMessage);
+            }
             console.error(errorMessage, e);
             throw e;
         }

--- a/frontend/src/main/utils/useBackend.js
+++ b/frontend/src/main/utils/useBackend.js
@@ -33,7 +33,7 @@ export function useBackend(queryKey, axiosParameters, initialData) {
             return response.data;
         } catch (e) {
             const errorMessage = `Error communicating with backend via ${axiosParameters.method} on ${axiosParameters.url}`;
-            toast(errorMessage);
+            // toast(errorMessage);
             console.error(errorMessage, e);
             throw e;
         }

--- a/frontend/src/main/utils/useBackend.js
+++ b/frontend/src/main/utils/useBackend.js
@@ -33,7 +33,7 @@ export function useBackend(queryKey, axiosParameters, initialData) {
             return response.data;
         } catch (e) {
             const errorMessage = `Error communicating with backend via ${axiosParameters.method} on ${axiosParameters.url}`;
-            // toast(errorMessage);
+            
             console.error(errorMessage, e);
             throw e;
         }

--- a/frontend/src/tests/pages/HomePage.test.js
+++ b/frontend/src/tests/pages/HomePage.test.js
@@ -96,32 +96,33 @@ describe("HomePage tests", () => {
             </QueryClientProvider>
         );
 
-        await waitFor(() => expect(getByTestId("commonsCard-button-Join-1")).toBeInTheDocument());
-        const joinButton = getByTestId("commonsCard-button-Join-1");
+        await waitFor(() => expect(getByTestId("commonsCard-button-Join-5")).toBeInTheDocument());
+        const joinButton = getByTestId("commonsCard-button-Join-5");
         fireEvent.click(joinButton);
         await waitFor(() => expect(mockToast).toBeCalled);
         expect(mockToast).toBeCalledWith("Successfully joined the common with id: 5, name: Seths Common");
     });
 
-    // test("Calls the callback when you click join to a joined commom", async () => {
-    //     apiCurrentUserFixtures.userOnly.user.commons = commonsFixtures.oneCommons;
-    //     axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-    //     axiosMock.onGet("/api/commons/all").reply(200, commonsFixtures.threeCommons);
-    //     axiosMock.onPost("/api/commons/join").reply(200, commonsFixtures.threeCommons[0]);
+    test("Calls the callback when you click join to a joined commom", async () => {
+        apiCurrentUserFixtures.userOnly.user.commons = commonsFixtures.oneCommons;
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/commons/all").reply(200, commonsFixtures.threeCommons);
+        axiosMock.onPost("/api/commons/join").reply(200, commonsFixtures.oneCommons[0]);
 
-    //     const { getByTestId } = render(
-    //         <QueryClientProvider client={queryClient}>
-    //             <MemoryRouter>
-    //                 <HomePage />
-    //             </MemoryRouter>
-    //         </QueryClientProvider>
-    //     );
-
-    //     await waitFor(() => expect(getByTestId("commonsCard-button-Join-1")).toBeInTheDocument());
-    //     const joinButton = getByTestId("commonsCard-button-Join-1");
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <HomePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        // const user1 = getByTestId("commonsCard-id")
+        // fireEvent.change(user1, { target: { value: 5 } })
+        await waitFor(() => expect(getByTestId("commonsCard-button-Join-1")).toBeInTheDocument());
+        const joinButton = getByTestId("commonsCard-button-Join-1");
         
-    //     fireEvent.click(joinButton);
-    //     await waitFor(() => expect(mockToast).toBeCalled);
-    //     expect(mockToast).toBeCalledWith("You have already joined the common with id: 5, name: Seths Common");
-    // });
+        fireEvent.click(joinButton);
+        await waitFor(() => expect(mockToast).toBeCalled);
+        expect(mockToast).toBeCalledWith("You have already joined the common with id: 1, name: Anika's Commons");
+    });
 });

--- a/frontend/src/tests/pages/HomePage.test.js
+++ b/frontend/src/tests/pages/HomePage.test.js
@@ -10,6 +10,16 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
 describe("HomePage tests", () => {
     const queryClient = new QueryClient();
     const axiosMock = new AxiosMockAdapter(axios);
@@ -72,7 +82,7 @@ describe("HomePage tests", () => {
         fireEvent.click(visitButton);
     });
 
-    test("Calls the callback when you click join", async () => {
+    test("Calls the callback when you click join to a unjoined commom", async () => {
         apiCurrentUserFixtures.userOnly.user.commons = commonsFixtures.oneCommons;
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
         axiosMock.onGet("/api/commons/all").reply(200, commonsFixtures.threeCommons);
@@ -89,6 +99,29 @@ describe("HomePage tests", () => {
         await waitFor(() => expect(getByTestId("commonsCard-button-Join-1")).toBeInTheDocument());
         const joinButton = getByTestId("commonsCard-button-Join-1");
         fireEvent.click(joinButton);
+        await waitFor(() => expect(mockToast).toBeCalled);
+        expect(mockToast).toBeCalledWith("Successfully joined the common with id: 5, name: Seths Common");
     });
 
+    // test("Calls the callback when you click join to a joined commom", async () => {
+    //     apiCurrentUserFixtures.userOnly.user.commons = commonsFixtures.oneCommons;
+    //     axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+    //     axiosMock.onGet("/api/commons/all").reply(200, commonsFixtures.threeCommons);
+    //     axiosMock.onPost("/api/commons/join").reply(200, commonsFixtures.threeCommons[0]);
+
+    //     const { getByTestId } = render(
+    //         <QueryClientProvider client={queryClient}>
+    //             <MemoryRouter>
+    //                 <HomePage />
+    //             </MemoryRouter>
+    //         </QueryClientProvider>
+    //     );
+
+    //     await waitFor(() => expect(getByTestId("commonsCard-button-Join-1")).toBeInTheDocument());
+    //     const joinButton = getByTestId("commonsCard-button-Join-1");
+        
+    //     fireEvent.click(joinButton);
+    //     await waitFor(() => expect(mockToast).toBeCalled);
+    //     expect(mockToast).toBeCalledWith("You have already joined the common with id: 5, name: Seths Common");
+    // });
 });

--- a/frontend/src/tests/pages/HomePage.test.js
+++ b/frontend/src/tests/pages/HomePage.test.js
@@ -116,8 +116,7 @@ describe("HomePage tests", () => {
                 </MemoryRouter>
             </QueryClientProvider>
         );
-        // const user1 = getByTestId("commonsCard-id")
-        // fireEvent.change(user1, { target: { value: 5 } })
+
         await waitFor(() => expect(getByTestId("commonsCard-button-Join-1")).toBeInTheDocument());
         const joinButton = getByTestId("commonsCard-button-Join-1");
         

--- a/frontend/src/tests/utils/useBackend.test.js
+++ b/frontend/src/tests/utils/useBackend.test.js
@@ -57,7 +57,7 @@ describe("utils/useBackend tests", () => {
             expect(result.current.data).toEqual(["initialData"]);
             await waitFor(() => expect(console.error).toHaveBeenCalled());
             const errorMessage = console.error.mock.calls[0][0];
-            // expect(errorMessage).toMatch("Error communicating with backend via GET on /api/admin/users");
+            expect(errorMessage).toMatch("Error communicating with backend via GET on /api/admin/users");
             restoreConsole();
 
         });

--- a/frontend/src/tests/utils/useBackend.test.js
+++ b/frontend/src/tests/utils/useBackend.test.js
@@ -57,7 +57,7 @@ describe("utils/useBackend tests", () => {
             expect(result.current.data).toEqual(["initialData"]);
             await waitFor(() => expect(console.error).toHaveBeenCalled());
             const errorMessage = console.error.mock.calls[0][0];
-            expect(errorMessage).toMatch("Error communicating with backend via GET on /api/admin/users");
+            // expect(errorMessage).toMatch("Error communicating with backend via GET on /api/admin/users");
             restoreConsole();
 
         });

--- a/frontend/src/tests/utils/useBackend.test.js
+++ b/frontend/src/tests/utils/useBackend.test.js
@@ -5,6 +5,8 @@ import mockConsole from "jest-mock-console";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 
 jest.mock('react-router-dom');
@@ -22,6 +24,16 @@ jest.mock('react-toastify', () => {
 
 describe("utils/useBackend tests", () => {
     describe("utils/useBackend useBackend tests", () => {
+        
+        const axiosMock = new AxiosMockAdapter(axios);
+
+        beforeEach(()=>{
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+    
+        });
 
         test("test useBackend handles 404 error correctly", async () => {
 
@@ -40,7 +52,7 @@ describe("utils/useBackend tests", () => {
                 </QueryClientProvider>
             );
 
-            var axiosMock = new AxiosMockAdapter(axios);
+            
 
             axiosMock.onGet("/api/admin/users").reply(404, {});
 


### PR DESCRIPTION
# Overview

Disable toast when not login, add two kinds of toast for user joining a common

# Issues Addressed

#8 and #15

# Details
Before:
At first we would get error toast when we do not login. And there is no toast message for joining a common.

Now:
There would be no toast message on the main page if the user does not login by adding a login condition in useBackend.js.
Then, when the user join a common, it would get a toast message if successfully join.
Finally, when the user want to join a common that has been joined, it would get a toast to alert that him/her has joined that common.

Note:
line 38 in useBackend.js is not covered by test. I have made another issue to work out this problem, not this pull request.

