### PR TITLE
Increase Controller Coverage

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -117,11 +117,11 @@ public class CommonsController extends ApiController {
   public ResponseEntity<Commons> deleteUserFromCommon(@PathVariable("commonsId") Long commonsId,
       @PathVariable("userId") Long userId) throws Exception {
 
-    Optional<UserCommons> uc = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId);
-    UserCommons userCommons = uc.orElseThrow(() -> new Exception(
-        String.format("UserCommons with commonsId=%d and userId=%d not found.", commonsId, userId)));
-
-    userCommonsRepository.deleteById(userCommons.getId());
+    UserCommons uc = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)
+      .orElseThrow(
+          () -> new EntityNotFoundException(UserCommons.class, "commonsId", commonsId, "userId", userId));;
+      
+    userCommonsRepository.deleteById(uc.getId());
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.times;
@@ -29,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.Map;
 import java.util.ArrayList;
 import java.util.Optional;
 
@@ -129,6 +131,148 @@ public class CommonsControllerTests extends ControllerTestCase {
     String cAsJson = mapper.writeValueAsString(c);
 
     assertEquals(responseString, cAsJson);
+  }
+
+  @WithMockUser(roles = { "USER" })
+  @Test
+  public void join_commons_nonexistent_test() throws Exception {
+    UserCommons uc = UserCommons.builder().userId(1L).commonsId(2L).totalWealth(0).build();
+
+    String requestBody = mapper.writeValueAsString(uc);
+
+    when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.empty());
+    when(commonsRepository.findById(eq(2L))).thenReturn(Optional.empty());
+
+    MvcResult response = mockMvc
+        .perform(post("/api/commons/join?commonsId=2").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+            .characterEncoding("utf-8").content(requestBody))
+        .andExpect(status().isNotFound()).andReturn();
+
+    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(2L, 1L);
+    verify(userCommonsRepository, times(1)).save(uc);
+    verify(commonsRepository, times(1)).findById(2L);
+
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("Commons with id 2 not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "USER" })
+  @Test
+  public void join_commons_already_joined_test() throws Exception {
+
+    Commons c = Commons.builder().id(2L).name("Example Commons").build();
+    UserCommons uc = UserCommons.builder().userId(1L).commonsId(2L).totalWealth(0).build();
+
+    String requestBody = mapper.writeValueAsString(uc);
+
+    when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.of(uc));
+    when(commonsRepository.findById(2L)).thenReturn(Optional.of(c));
+
+    MvcResult response = mockMvc
+        .perform(post("/api/commons/join?commonsId=2").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+            .characterEncoding("utf-8").content(requestBody))
+        .andExpect(status().isOk()).andReturn();
+
+    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(2L, 1L);
+    verify(userCommonsRepository, times(0)).save(uc);
+
+    String responseString = response.getResponse().getContentAsString();
+    String cAsJson = mapper.writeValueAsString(c);
+
+    assertEquals(responseString, cAsJson);
+  }
+
+  @WithMockUser(roles = { "USER" })
+  @Test
+  public void join_commons_already_joined_nonexistent_test() throws Exception {
+
+    Commons c = Commons.builder().id(2L).name("Example Commons").build();
+    UserCommons uc = UserCommons.builder().userId(1L).commonsId(2L).totalWealth(0).build();
+
+    String requestBody = mapper.writeValueAsString(uc);
+
+    when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.of(uc));
+    when(commonsRepository.findById(2L)).thenReturn(Optional.empty());
+
+    MvcResult response = mockMvc
+        .perform(post("/api/commons/join?commonsId=2").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+            .characterEncoding("utf-8").content(requestBody))
+        .andExpect(status().isNotFound()).andReturn();
+
+    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(2L, 1L);
+    verify(userCommonsRepository, times(0)).save(uc);
+
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("Commons with id 2 not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void delete_user_from_commons_test() throws Exception {
+    UserCommons uc = UserCommons.builder().id(1).commonsId(42).userId(3).build();
+
+    when(userCommonsRepository.findByCommonsIdAndUserId(42L, 3L)).thenReturn(Optional.of(uc));
+
+    MvcResult response = mockMvc
+        .perform(delete("/api/commons/42/users/3").with(csrf()))
+        .andExpect(status().isNoContent()).andReturn();
+
+    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(42L, 3L);
+    verify(userCommonsRepository, times(1)).deleteById(1L);
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void delete_user_from_commons_nonexistent_test() throws Exception {
+    when(userCommonsRepository.findByCommonsIdAndUserId(42L, 3L)).thenReturn(Optional.empty());
+    
+    MvcResult response = mockMvc
+        .perform(delete("/api/commons/42/users/3").with(csrf()))
+        .andDo(print())
+        .andExpect(status().isNotFound()).andReturn();
+
+    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(42L, 3L);
+
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("UserCommons with commonsId 42 and userId 3 not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "USER" })
+  @Test
+  public void get_commons_by_id_test() throws Exception {
+    Commons c = Commons.builder().id(2L).name("Example Commons").build();
+
+    when(commonsRepository.findById(2L)).thenReturn(Optional.of(c));
+
+    MvcResult response = mockMvc
+        .perform(get("/api/commons?id=2"))
+        .andExpect(status().isOk()).andReturn();
+
+    verify(commonsRepository, times(1)).findById(2L);
+    
+    String responseString = response.getResponse().getContentAsString();
+    String cAsJson = mapper.writeValueAsString(c);
+
+    assertEquals(responseString, cAsJson);
+  }
+
+  @WithMockUser(roles = { "USER" })
+  @Test
+  public void get_commons_by_id_nonexistent_test() throws Exception {
+    when(commonsRepository.findById(2L)).thenReturn(Optional.empty());
+
+    MvcResult response = mockMvc
+        .perform(get("/api/commons?id=2"))
+        .andExpect(status().isNotFound()).andReturn();
+
+    verify(commonsRepository, times(1)).findById(2L);
+    
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("Commons with id 2 not found", json.get("message"));
   }
 
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -1,41 +1,29 @@
 package edu.ucsb.cs156.happiercows.controllers;
 
-import edu.ucsb.cs156.happiercows.ControllerTestCase;
-import edu.ucsb.cs156.happiercows.repositories.UserRepository;
-import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
-import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
-import edu.ucsb.cs156.happiercows.entities.Commons;
-import edu.ucsb.cs156.happiercows.entities.User;
-import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Map;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.http.MediaType;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import org.springframework.beans.factory.annotation.Autowired;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.eq;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.List;
-import java.util.Map;
-import java.util.ArrayList;
-import java.util.Optional;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.happiercows.ControllerTestCase;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 
 @WebMvcTest(controllers = UserCommonsController.class)
 public class UserCommonsControllerTests extends ControllerTestCase {

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -1,0 +1,116 @@
+package edu.ucsb.cs156.happiercows.controllers;
+
+import edu.ucsb.cs156.happiercows.ControllerTestCase;
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.User;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.http.MediaType;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.ArrayList;
+import java.util.Optional;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@WebMvcTest(controllers = UserCommonsController.class)
+public class UserCommonsControllerTests extends ControllerTestCase {
+
+  @MockBean
+  UserCommonsRepository userCommonsRepository;
+
+  @MockBean
+  UserRepository userRepository;
+
+  @MockBean
+  CommonsRepository commonsRepository;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void get_user_commons_by_id_admin_test() throws Exception {
+    UserCommons uc = UserCommons.builder().id(1).commonsId(42).userId(3).build();
+
+    when(userCommonsRepository.findByCommonsIdAndUserId(42L, 3L)).thenReturn(Optional.of(uc));
+    MvcResult response = mockMvc.perform(get("/api/usercommons?userId=3&commonsId=42"))
+        .andExpect(status().isOk()).andReturn();
+
+    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(42L, 3L);
+
+    String responseString = response.getResponse().getContentAsString();
+    UserCommons result = objectMapper.readValue(responseString, UserCommons.class);
+    assertEquals(result, uc);
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void get_user_commons_by_id_admin_nonexistent_test() throws Exception {
+    when(userCommonsRepository.findByCommonsIdAndUserId(42L, 3L)).thenReturn(Optional.empty());
+    MvcResult response = mockMvc.perform(get("/api/usercommons?userId=3&commonsId=42"))
+        .andExpect(status().isNotFound()).andReturn();
+
+    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(42L, 3L);
+
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("UserCommons with commonsId 42 and userId 3 not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "USER" })
+  @Test
+  public void get_user_commons_by_id_test() throws Exception {
+    UserCommons uc = UserCommons.builder().id(1).commonsId(42).userId(1).build();
+
+    when(userCommonsRepository.findByCommonsIdAndUserId(42L, 1L)).thenReturn(Optional.of(uc));
+    MvcResult response = mockMvc.perform(get("/api/usercommons/forcurrentuser?commonsId=42"))
+        .andExpect(status().isOk()).andReturn();
+
+    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(42L, 1L);
+
+    String responseString = response.getResponse().getContentAsString();
+    UserCommons result = objectMapper.readValue(responseString, UserCommons.class);
+    assertEquals(result, uc);
+  }
+
+  @WithMockUser(roles = { "USER" })
+  @Test
+  public void get_user_commons_by_id_nonexistent_test() throws Exception {
+
+    when(userCommonsRepository.findByCommonsIdAndUserId(42L, 1L)).thenReturn(Optional.empty());
+    MvcResult response = mockMvc.perform(get("/api/usercommons/forcurrentuser?commonsId=42"))
+        .andExpect(status().isNotFound()).andReturn();
+
+    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(42L, 1L);
+
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("UserCommons with commonsId 42 and userId 1 not found", json.get("message"));
+  }
+
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UsersControllerTests.java
@@ -1,5 +1,15 @@
 package edu.ucsb.cs156.happiercows.controllers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -11,16 +21,6 @@ import edu.ucsb.cs156.happiercows.ControllerTestCase;
 import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import edu.ucsb.cs156.happiercows.testconfig.TestConfig;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-import java.util.ArrayList;
-import java.util.Arrays;
 
 @WebMvcTest(controllers = UsersController.class)
 @Import(TestConfig.class)


### PR DESCRIPTION
# Overview

This PR seeks to increase the coverage of the provided controller code, per #13. Several critical modules began with low jacoco coverage, and this PR increases them all to 100%.

### Acceptance Criteria

Reach 100% jacoco coverage for the following backend files:
- [x] `CommonsController`
- [x] `UserCommonsController`

# Details

CommonsController:
<img width="1053" alt="Screen Shot 2022-03-08 at 8 54 09 PM" src="https://user-images.githubusercontent.com/24759371/157375426-74471cc2-235b-4e97-b9b7-066108c0d236.png">

UserCommonsController:
<img width="1021" alt="Screen Shot 2022-03-09 at 1 05 40 PM" src="https://user-images.githubusercontent.com/24759371/157535997-b1cc0c93-4c26-4c6c-b091-df394b62ce91.png">


