### PR TITLE
Increase Profits and ProfitsTable Mutation Coverage

### DIFF
--- a/frontend/src/tests/components/Commons/Profits.test.js
+++ b/frontend/src/tests/components/Commons/Profits.test.js
@@ -2,6 +2,7 @@ import { render } from "@testing-library/react";
 import Profits from "main/components/Commons/Profits"; 
 import userCommonsFixtures from "fixtures/userCommonsFixtures"; 
 import profitsFixtures from "fixtures/profitsFixtures";
+import moment from "moment";
 
 describe("Profits tests", () => {
 
@@ -15,5 +16,41 @@ describe("Profits tests", () => {
         render(
             <Profits userCommons={userCommonsFixtures.oneUserCommons[0]} profits={[]} />
         );
+    });
+
+    test("renders properly with specified profits", () => {
+        const { getByTestId } = render(
+            <Profits userCommons={userCommonsFixtures.oneUserCommons[0]} profits={profitsFixtures.threeProfits} />
+        );
+
+        // Ensure headers are correct
+
+        // Profit header
+        const profit_header = getByTestId('ProfitsTable-header-profit');
+        expect(profit_header).toBeInTheDocument();
+        expect(typeof(profit_header.textContent)).toBe('string');
+        expect(profit_header.textContent).toEqual("Profit");
+
+        // Date header
+        const date_header = getByTestId('ProfitsTable-header-date');
+        expect(date_header).toBeInTheDocument();
+        expect(typeof(date_header.textContent)).toBe('string');
+        expect(date_header.textContent).toEqual("Date");
+
+        // Ensure all profits and dates are equal to those specified in the fixture
+
+        for (let i = 0; i < 3; i++) {
+            // Profit
+            const profit = getByTestId(`ProfitsTable-cell-row-${i}-col-profit`);
+            expect(profit).toBeInTheDocument();
+            expect(typeof(profit.textContent)).toBe('string');
+            expect(+profit.textContent).toEqual(profitsFixtures.threeProfits[i].profit);
+
+            // Date
+            const date = getByTestId(`ProfitsTable-cell-row-${i}-col-date`);
+            expect(date).toBeInTheDocument();
+            expect(typeof(date.textContent)).toBe('string');
+            expect(date.textContent).toEqual(moment(profitsFixtures.threeProfits[i].timestamp).format('YYYY-MM-DD'));
+        }
     });
 });

--- a/frontend/src/tests/components/Commons/ProfitsTable.test.js
+++ b/frontend/src/tests/components/Commons/ProfitsTable.test.js
@@ -15,4 +15,41 @@ describe("Profits tests", () => {
             <ProfitsTable profits={[]} />
         );
     });
+
+    test("renders properly with specified profits", () => {
+        const { getByTestId } = render(
+            <ProfitsTable profits={profitsTableFixtures.threeFormattedProfits} />
+        );
+
+        // Ensure headers are correct
+
+        // Profit header
+        const profit_header = getByTestId('ProfitsTable-header-profit');
+        expect(profit_header).toBeInTheDocument();
+        expect(typeof(profit_header.textContent)).toBe('string');
+        expect(profit_header.textContent).toEqual("Profit");
+
+        // Date header
+        const date_header = getByTestId('ProfitsTable-header-date');
+        expect(date_header).toBeInTheDocument();
+        expect(typeof(date_header.textContent)).toBe('string');
+        expect(date_header.textContent).toEqual("Date");
+
+        // Ensure all profits and dates are equal to those specified in the fixture
+
+        for (let i = 0; i < 3; i++) {
+            // Profit
+            const profit = getByTestId(`ProfitsTable-cell-row-${i}-col-profit`);
+            expect(profit).toBeInTheDocument();
+            expect(typeof(profit.textContent)).toBe('string');
+            expect(+profit.textContent).toEqual(profitsTableFixtures.threeFormattedProfits[i].profit);
+
+            // Date
+            const date = getByTestId(`ProfitsTable-cell-row-${i}-col-date`);
+            expect(date).toBeInTheDocument();
+            expect(typeof(date.textContent)).toBe('string');
+            expect(date.textContent).toEqual(profitsTableFixtures.threeFormattedProfits[i].date);
+        }
+    });
+
 });


### PR DESCRIPTION
# Overview

This pull request attempts to increase the mutation testing coverage for the Profits and ProfitsTable components, per #49.

### Acceptance Criteria

- [x] 100% of mutants killed by Profits tests
- [x] 100% of mutants (on lines that are not disabled) killed by ProfitsTable tests

# Details

Profits mutation testing:
<img width="571" alt="Screen Shot 2022-03-10 at 8 39 09 PM" src="https://user-images.githubusercontent.com/24759371/157803805-2a57c98d-ef51-4ae7-a41c-2c4f07b61994.png">

ProfitsTable mutation testing:
<img width="808" alt="Screen Shot 2022-03-10 at 8 41 14 PM" src="https://user-images.githubusercontent.com/24759371/157803829-e3a3b357-523b-40ee-90bd-f73a778af948.png">

Note that the only remaining mutants are ArrayDeclaration mutations on lines where such mutations have been disabled. The lines were disabled in the starter code, as they represent an optimization, so mutating the arrays will still produce a correct result:
<img width="760" alt="Screen Shot 2022-03-10 at 8 41 31 PM" src="https://user-images.githubusercontent.com/24759371/157803943-35f22c43-7d22-4ce4-9bb1-40d7d085f06f.png">

Thus, both components have effectively killed 100% of mutants.
