### PR TITLE
W22 5pm 3 ig implement current day and end date in commonsOverview

### DIFF
--- a/frontend/src/main/components/Commons/CommonsOverview.js
+++ b/frontend/src/main/components/Commons/CommonsOverview.js
@@ -1,12 +1,25 @@
 import React from "react";
 import { Card } from "react-bootstrap";
+import moment from "moment";
+
+function getStartDate(timestamp) {
+    return moment(timestamp).format('YYYY-MM-DD');
+}
+
+function getEndDate(timestamp, duration) {
+    return moment(timestamp).add(duration+1,'days').format('MM/DD/YYYY');
+}
 
 export default function CommonsOverview({ commons }) {
+    var currentDay = moment();
+    var startDate = getStartDate(commons.startDate);
+    var endDate = getEndDate(commons.startDate, commons.duration);
+    currentDay = currentDay.diff(startDate, 'days');
     return (
         <Card data-testid="CommonsOverview">
             <Card.Header as="h5">Announcements</Card.Header>
             <Card.Body>
-                <Card.Title>Today is day {commons.day}! This game will end on {commons.endDate}.</Card.Title>
+                <Card.Title>Today is day {currentDay}! This game will end on {endDate}.</Card.Title>
                 <Card.Text>Total Players: {commons.totalPlayers}</Card.Text>
             </Card.Body>
         </Card>

--- a/frontend/src/main/components/Commons/CommonsOverview.js
+++ b/frontend/src/main/components/Commons/CommonsOverview.js
@@ -7,7 +7,7 @@ function getStartDate(timestamp) {
 }
 
 function getEndDate(timestamp, duration) {
-    return moment(timestamp).add(duration+1,'days').format('MM/DD/YYYY');
+    return moment(timestamp).add({days: duration+1}).format('MM/DD/YYYY');
 }
 
 export default function CommonsOverview({ commons }) {
@@ -19,9 +19,11 @@ export default function CommonsOverview({ commons }) {
         <Card data-testid="CommonsOverview">
             <Card.Header as="h5">Announcements</Card.Header>
             <Card.Body>
-                <Card.Title>Today is day {currentDay}! This game will end on {endDate}.</Card.Title>
+                <Card.Title data-testid="title">Today is day {currentDay}! This game will end on {endDate}.</Card.Title>
                 <Card.Text>Total Players: {commons.totalPlayers}</Card.Text>
             </Card.Body>
         </Card>
     );
 }; 
+
+export { getStartDate, getEndDate };

--- a/frontend/src/main/components/Commons/CreateCommonsForm.js
+++ b/frontend/src/main/components/Commons/CreateCommonsForm.js
@@ -1,7 +1,9 @@
 import { Button, Form } from "react-bootstrap";
 import { useForm } from "react-hook-form";
+import moment from "moment";
 
 export default function CreateCommonsForm(props) {
+  var currentDay = moment().format('YYYY-MM-DD')
   const { onSubmit } = props;
   const {
     register,
@@ -83,6 +85,7 @@ export default function CreateCommonsForm(props) {
         <Form.Control
           id="startDate"
           type="date"
+          min={currentDay}
           isInvalid={!!errors.startDate}
           {...register("startDate", {
             valueAsDate: true,
@@ -93,6 +96,24 @@ export default function CreateCommonsForm(props) {
         />
         <Form.Control.Feedback type="invalid">
           {errors.startDate?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="duration">Duration of Game</Form.Label>
+        <Form.Control
+          id="duration"
+          type="number"
+          step="1"
+          isInvalid={!!errors.duration}
+          {...register("duration", {
+            valueAsNumber: true,
+            required: "Duration is required",
+            min: { value: 1, message: "Duration must be positive" },
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.duration?.message}
         </Form.Control.Feedback>
       </Form.Group>
       <Button type="submit" data-testid="CreateCommonsForm-Create-Button">Create</Button>

--- a/frontend/src/tests/components/Commons/CommonsOverview.test.js
+++ b/frontend/src/tests/components/Commons/CommonsOverview.test.js
@@ -1,12 +1,35 @@
 import { render } from "@testing-library/react";
-import CommonsOverview from "main/components/Commons/CommonsOverview"; 
+import CommonsOverview from "main/components/Commons/CommonsOverview";
+import { getStartDate, getEndDate } from "main/components/Commons/CommonsOverview";  
 import commonsFixtures from "fixtures/commonsFixtures"; 
+import moment from "moment";
 
 describe("CommonsOverview tests", () => {
 
     test("renders without crashing", () => {
-        render(
+        const { getByTestId } = render(
             <CommonsOverview commons={commonsFixtures.oneCommons[0]} />
         );
+
+        function test_getStartDate(timestamp) {
+            return moment(timestamp).format('YYYY-MM-DD');
+        }
+        
+        function test_getEndDate(timestamp, duration) {
+            return moment(timestamp).add({days: duration+1}).format('MM/DD/YYYY');
+        }
+
+        var duration = -1;
+        var currentDay = moment();
+        var startDate = test_getStartDate(currentDay);
+        var endDate = test_getEndDate(startDate, duration);
+        currentDay = currentDay.diff(startDate, "days");
+        const title = getByTestId('title');
+        expect(title).toBeInTheDocument();
+        expect(typeof(title.textContent)).toBe('string');
+        expect(test_getStartDate(currentDay)).toEqual(getStartDate(currentDay));
+        expect(test_getEndDate(startDate, duration+10)).toEqual(getEndDate(startDate, duration+10));
+        expect("Today is day " + currentDay + "! This game will end on " + endDate + ".").toEqual(title.textContent);
+        
     });
 });

--- a/frontend/src/tests/components/Commons/CreateCommonsForm.test.js
+++ b/frontend/src/tests/components/Commons/CreateCommonsForm.test.js
@@ -27,6 +27,7 @@ describe(CreateCommonsForm, () => {
     userEvent.type(screen.getByLabelText(/cow price/i), "99.95");
     userEvent.type(screen.getByLabelText(/milk price/i), "5.99");
     userEvent.type(screen.getByLabelText(/start date/i), "2021-01-01");
+    userEvent.type(screen.getByLabelText(/duration of game/i), "15")
     userEvent.click(screen.getByRole("button"));
 
     await waitFor(() => expect(onSubmit).toBeCalledTimes(1));
@@ -36,6 +37,7 @@ describe(CreateCommonsForm, () => {
       cowPrice: 99.95,
       milkPrice: 5.99,
       startDate: new Date("2021-01-01"),
+      duration: 15,
     });
   });
 });

--- a/frontend/src/tests/pages/AdminCreateCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminCreateCommonsPage.test.js
@@ -73,6 +73,7 @@ describe("AdminCreateCommonsPage tests", () => {
         const cowPriceField = getByLabelText("Cow Price");
         const milkPriceField = getByLabelText("Milk Price");
         const startDateField = getByLabelText("Start Date");
+        const durationField = getByLabelText("Duration of Game");
         const button = getByTestId("CreateCommonsForm-Create-Button");
 
 
@@ -81,6 +82,7 @@ describe("AdminCreateCommonsPage tests", () => {
         fireEvent.change(cowPriceField, { target: { value: '10' } })
         fireEvent.change(milkPriceField, { target: { value: '5' } })
         fireEvent.change(startDateField, { target: { value: '2022-05-12' } })
+        fireEvent.change(durationField, { target: { value: '15' } })
         fireEvent.click(button);
 
         await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
@@ -90,7 +92,8 @@ describe("AdminCreateCommonsPage tests", () => {
             startingBalance: 500,
             cowPrice: 10,
             milkPrice: 5,
-            startDate: '2022-05-12T00:00:00.000Z'
+            startDate: '2022-05-12T00:00:00.000Z',
+            duration: 15
         };
 
         expect(axiosMock.history.post[0].data).toEqual( JSON.stringify(expectedCommons) );

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -73,7 +73,11 @@ public class CommonsController extends ApiController {
   public ResponseEntity<String> createCommons(@ApiParam("name of commons") @RequestBody CreateCommonsParams params)
       throws JsonProcessingException {
     log.info("name={}", params.getName());
-    Commons c = Commons.builder().name(params.getName()).build();
+    Commons c = Commons.builder()
+      .name(params.getName())
+      .startDate(params.getStartDate())
+      .duration(params.getDuration())
+      .build();
     Commons savedCommons = commonsRepository.save(c);
     String body = mapper.writeValueAsString(savedCommons);
     log.info("body={}", body);

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -22,6 +22,8 @@ public class Commons {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long id;  
   private String name;
+  private String startDate;
+  private int duration;
 
   @ManyToMany(fetch = FetchType.EAGER, cascade = {CascadeType.PERSIST,CascadeType.REMOVE})
   @JoinTable(name = "user_commons", 

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
@@ -3,6 +3,7 @@ package edu.ucsb.cs156.happiercows.models;
 import lombok.Data;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
+import net.bytebuddy.asm.Advice.Local;
 import lombok.Builder;
 import lombok.AccessLevel;
 
@@ -22,4 +23,6 @@ public class CreateCommonsParams {
   private double cowPrice;
   private double milkPrice;
   private double startingBalance;
+  private String startDate;
+  private int duration;
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
@@ -3,7 +3,6 @@ package edu.ucsb.cs156.happiercows.models;
 import lombok.Data;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
-import net.bytebuddy.asm.Advice.Local;
 import lombok.Builder;
 import lombok.AccessLevel;
 


### PR DESCRIPTION
# Overview

This PR creates a `startDate` and `duration` variable to `Commons.java`. I add these as parameters to the Create Commons Swagger API in `CommonsController.java` as well as implement UI Form Groups in `CreateCommonsForm.js`. I also use the moment library to retrieve the current day and calculate the end date based off the start date and duration of the game. The reason why this PR is created is because we want to display the current date and the last day of the game.

# Issues Addressed
#38 

# Details
Coverage:
<img width="566" alt="Screen Shot 2022-03-11 at 4 51 30 AM" src="https://user-images.githubusercontent.com/73454322/157870028-700ece6c-a19f-46cf-b656-eb95df3a3028.png">

Mutation Tests for CommonsOverviewTest.js:
<img width="564" alt="Screen Shot 2022-03-11 at 4 49 50 AM" src="https://user-images.githubusercontent.com/73454322/157869782-ac0877da-3c0f-479c-b4fd-0c34f9b0c9a5.png">

