### PR TITLE
refresh on logout

### DIFF
--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -59,7 +59,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 currentUser && currentUser.loggedIn ? (
                   <>
                     <Navbar.Text className="me-3" as={Link} to="/profile">Welcome, {currentUser.root.user.email}</Navbar.Text>
-                    <Button onClick={doLogout}>Log Out</Button>
+                    <Button href="/" onClick={doLogout}>Log Out</Button>
                   </>
                 ) : (
                   <Button href="/oauth2/authorization/google">Log In</Button>


### PR DESCRIPTION
# Overview

Working on log out. When logging out, trying to make join and visit buttons disappear. Also trying to make joined commons disappear as well. 

# Issues Addressed

#53 

# Details

Currently just made it so that when log out button is clicked, the page is refreshed so the commons and buttons for commons disappear. Thinking about whether to try and make commons (not the joined commons) visible even when user is logged out, but not give any clickable buttons
