### PR TITLE
w22 5pm 4 ay je - additional commons controller permissions tests

### DIFF
--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -422,5 +422,93 @@ public class CommonsControllerTests extends ControllerTestCase {
     assertEquals("Commons with id 2 not found", json.get("message"));
   }
 
+  // get all
+ @Test
+ public void api_commons_all__logged_out__returns_403() throws Exception {
+   mockMvc.perform(get("/api/commons/all"))
+       .andExpect(status().is(403));
+ }
+
+ @WithMockUser(roles = { "USER" , "ADMIN"})
+ @Test
+ public void api_commons_all__logged_in__returns_ok() throws Exception {
+   mockMvc.perform(get("/api/commons/all"))
+     .andExpect(status().isOk());
+ }
+
+ // get
+ @Test
+ public void api_commons_get__logged_out__returns_403() throws Exception {
+   mockMvc.perform(get("/api/commons?id=1"))
+       .andExpect(status().is(403));
+ }
+
+
+ // join commons
+ @Test
+ public void api_commons_join__logged_out__returns_403() throws Exception {
+   mockMvc.perform(post("/api/commons/join"))
+     .andExpect(status().is(403));
+ }
+
+ // Authorization tests for /api/commons/post
+
+ @Test
+ public void api_commons_post__logged_out__returns_403() throws Exception {
+   mockMvc.perform(post("/api/commons/new"))
+     .andExpect(status().is(403));
+ }
+
+ @WithMockUser(roles = { "USER" })
+ @Test
+ public void api_commons_post__user_logged_in__returns_403() throws Exception {
+   mockMvc.perform(post("/api/commons/new"))
+     .andExpect(status().is(403));
+ }
+
+ // Authorization tests for /api/commons/put
+ @Test
+ public void api_commons_put__logged_out__returns_403() throws Exception {
+   mockMvc.perform(post("/api/commons?id=1"))
+     .andExpect(status().is(403));
+ }
+
+ @WithMockUser(roles = { "USER" })
+ @Test
+ public void api_commons_put__user_logged_in__returns_403() throws Exception {
+   mockMvc.perform(post("/api/commons?id=1"))
+     .andExpect(status().is(403));
+ }
+
+
+ // Authorization tests for /api/commons/{commonsId}/users/{userId}
+ // delete user
+ @Test
+ public void api_commons_delete_user__logged_out__returns_403() throws Exception {
+   mockMvc.perform(post("/api/commons/1/users/1"))
+     .andExpect(status().is(403));
+ }
+
+ @WithMockUser(roles = { "USER" })
+ @Test
+ public void api_commons_delete_user__user_logged_in__returns_403() throws Exception {
+   mockMvc.perform(post("/api/commons/1/users/1"))
+     .andExpect(status().is(403));
+ }
+
+ // Authorization tests for /api/commons/delete
+  @Test
+ public void api_commons_delete__logged_out__returns_403() throws Exception {
+   mockMvc.perform(post("/api/commons/delete"))
+     .andExpect(status().is(403));
+ }
+
+ @WithMockUser(roles = { "USER" })
+ @Test
+ public void api_commons_delete__user_logged_in__returns_403() throws Exception {
+   mockMvc.perform(post("/api/commons/delete"))
+     .andExpect(status().is(403));
+ }
+
 
 }


### PR DESCRIPTION
# Overview

This PR adapted from [PR 46](https://github.com/ucsb-cs156-w22/team04-w22-5pm-HappyCows/pull/46) to clarify the scope of changes introduced by @jasonem225 

Added additional tests for commons controller concerning user authorization, such as checking if a logged out user can access functions that only logged in users/admins can use, such as join common, and checks logged in users cannot use admin functions, such as edit or delete

# Issues Addressed

#45 

- [x] add logged out checks, cannot use user/admin endpoints
- [x] add user checks, cannot use admin endpoints
